### PR TITLE
No longer based on Authentication; new interface: PasswordHolder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 # Spring Boot Starter Password Validation
 
-TODO
+This library makes validating new passwords easy.  
 
-Configuration:
+Steps necessary to make this library work in your application:
+- Configure the validations you want. See the available configurations below.
+- Make your user (or equivalent) class implement the interface `PasswordHolder`. This provides the validators a way to retrieve the current (encoded) password. This is required for certain validators.
+- Autowire the `PasswordValidator` bean in your application. Use the `PasswordValidator.validate(newPassword, passwordHolder)` method to validate new passwords. An exception of type `PasswordValidationFailedException` is thrown when a validation fails. No exception? Your new password is valid for use.
+- If desired: you can add new validation rules by implementing the `ValidationRule` interface.
+
+# Configuration:
 
 ```yaml
 password:
@@ -16,26 +22,32 @@ password:
 
 ### password.different-than-current-enabled
 Default: `false`  
+Type: `boolean`  
 Enables the validation where the password is not allowed to be the password the user is currently using.
 
 ### password.minimum-length-enabled
 Default: `false`  
+Type: `boolean`  
 Enables the minimum length check. See also property: password.minimum-length.
 
 ### password.not-used-in-past-enabled
 Default: `false`  
+Type: `boolean`  
 Enables the validation where the password is not allowed to have been used in the past by the same user.  
 Requires you to provide a bean of `OldPasswordRepository` as a means to retrieve the old passwords.
 
 ### password.strength-enabled
 Default: `false`  
-Enables the strength check. Meaning the password must be valida according to a specific regex expression. See also property: password.strength-regex.
+Type: `boolean`  
+Enables the strength check. Meaning the password must be valid according to a specific regex expression. See also property: password.strength-regex.
 
 ### password.minimum-length
 Default: `8`  
+Type: `int`  
 Only used when password.minimum-length-enabled is turned on. Defines the minimum length of passwords; shorter passwords will be denied.
 
 
 ### password.strength-regex
 Default: `^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[@#$%^&+=.,?!])(?=\S+$).*$`  
+Type: `String`  
 Only used when password.strength-enabled is turned on. Defines the regex for the strength check. The default checks for at least one capital letter, one lower case letter, one number and one special character.

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
@@ -99,7 +100,7 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-    
+
     <build>
         <pluginManagement>
             <plugins>

--- a/src/main/java/nl/_42/password/validation/CredentialRetriever.java
+++ b/src/main/java/nl/_42/password/validation/CredentialRetriever.java
@@ -1,9 +1,0 @@
-package nl._42.password.validation;
-
-import java.util.Optional;
-
-import org.springframework.security.core.Authentication;
-
-public interface CredentialRetriever {
-    Optional<String> getCredentials(Authentication authentication);
-}

--- a/src/main/java/nl/_42/password/validation/OldPasswordRepository.java
+++ b/src/main/java/nl/_42/password/validation/OldPasswordRepository.java
@@ -2,8 +2,6 @@ package nl._42.password.validation;
 
 import java.util.Set;
 
-import org.springframework.security.core.Authentication;
-
 public interface OldPasswordRepository {
-    Set<String> getOldPasswords(Authentication authentication);
+    Set<String> getOldPasswords(PasswordHolder passwordHolder);
 }

--- a/src/main/java/nl/_42/password/validation/PasswordHolder.java
+++ b/src/main/java/nl/_42/password/validation/PasswordHolder.java
@@ -1,0 +1,5 @@
+package nl._42.password.validation;
+
+public interface PasswordHolder {
+    String getPassword();
+}

--- a/src/main/java/nl/_42/password/validation/PasswordValidator.java
+++ b/src/main/java/nl/_42/password/validation/PasswordValidator.java
@@ -1,17 +1,16 @@
 package nl._42.password.validation;
 
-import lombok.AllArgsConstructor;
-import org.springframework.security.core.Authentication;
-
 import java.util.List;
+
+import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
 public class PasswordValidator {
 
     private final List<ValidationRule> rules;
 
-    public void validate(String password, Authentication authentication) {
-        rules.forEach(rule -> rule.validate(password, authentication));
+    public void validate(String password, PasswordHolder passwordHolder) {
+        rules.forEach(rule -> rule.validate(password, passwordHolder));
     }
 
 }

--- a/src/main/java/nl/_42/password/validation/PasswordValidatorAutoConfiguration.java
+++ b/src/main/java/nl/_42/password/validation/PasswordValidatorAutoConfiguration.java
@@ -2,10 +2,8 @@ package nl._42.password.validation;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -20,12 +18,6 @@ public class PasswordValidatorAutoConfiguration {
     @Bean
     public PasswordValidator passwordValidator() {
         return new PasswordValidator(rules);
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
-    public CredentialRetriever credentialRetriever() {
-        return authentication -> Optional.ofNullable(authentication.getCredentials()).map(Object::toString);
     }
 
 }

--- a/src/main/java/nl/_42/password/validation/ValidationRule.java
+++ b/src/main/java/nl/_42/password/validation/ValidationRule.java
@@ -1,9 +1,7 @@
 package nl._42.password.validation;
 
-import org.springframework.security.core.Authentication;
-
 public interface ValidationRule {
 
-    void validate(String password, Authentication authentication);
+    void validate(String password, PasswordHolder passwordHolder);
 
 }

--- a/src/main/java/nl/_42/password/validation/rule/PasswordDifferentThanCurrentRule.java
+++ b/src/main/java/nl/_42/password/validation/rule/PasswordDifferentThanCurrentRule.java
@@ -1,15 +1,12 @@
 package nl._42.password.validation.rule;
 
-import java.util.Optional;
-
 import lombok.extern.slf4j.Slf4j;
-import nl._42.password.validation.CredentialRetriever;
+import nl._42.password.validation.PasswordHolder;
 import nl._42.password.validation.PasswordValidationErrorCodes;
 import nl._42.password.validation.PasswordValidationFailedException;
 import nl._42.password.validation.ValidationRule;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
@@ -19,22 +16,15 @@ import org.springframework.stereotype.Component;
 public class PasswordDifferentThanCurrentRule implements ValidationRule {
 
     private final PasswordEncoder passwordEncoder;
-    private final CredentialRetriever credentialRetriever;
 
-    public PasswordDifferentThanCurrentRule(PasswordEncoder passwordEncoder, CredentialRetriever credentialRetriever) {
+    public PasswordDifferentThanCurrentRule(PasswordEncoder passwordEncoder) {
         this.passwordEncoder = passwordEncoder;
-        this.credentialRetriever = credentialRetriever;
     }
 
     @Override
-    public void validate(String password, Authentication authentication) {
-        Optional<String> credentials = credentialRetriever.getCredentials(authentication);
-        if (credentials.isEmpty()) {
-            log.warn("Credentials could not be obtained. PasswordDifferentThanCurrentRule is skipped.");
-            return;
-        }
+    public void validate(String password, PasswordHolder passwordHolder) {
 
-        if (passwordEncoder.matches(password, credentials.get())) {
+        if (passwordEncoder.matches(password, passwordHolder.getPassword())) {
             throw new PasswordValidationFailedException(PasswordValidationErrorCodes.MATCHES_CURRENT);
         }
     }

--- a/src/main/java/nl/_42/password/validation/rule/PasswordLengthRule.java
+++ b/src/main/java/nl/_42/password/validation/rule/PasswordLengthRule.java
@@ -1,12 +1,12 @@
 package nl._42.password.validation.rule;
 
+import nl._42.password.validation.PasswordHolder;
 import nl._42.password.validation.PasswordProperties;
 import nl._42.password.validation.PasswordValidationErrorCodes;
 import nl._42.password.validation.PasswordValidationFailedException;
 import nl._42.password.validation.ValidationRule;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -20,7 +20,7 @@ public class PasswordLengthRule implements ValidationRule {
     }
 
     @Override
-    public void validate(String password, Authentication authentication) {
+    public void validate(String password, PasswordHolder passwordHolder) {
         if (!password.matches("^.{" + passwordProperties.getMinimumLength() + ",100}$")) {
             throw new PasswordValidationFailedException(PasswordValidationErrorCodes.NOT_LONG_ENOUGH);
         }

--- a/src/main/java/nl/_42/password/validation/rule/PasswordNotUsedInPastRule.java
+++ b/src/main/java/nl/_42/password/validation/rule/PasswordNotUsedInPastRule.java
@@ -1,12 +1,12 @@
 package nl._42.password.validation.rule;
 
+import nl._42.password.validation.OldPasswordRepository;
+import nl._42.password.validation.PasswordHolder;
 import nl._42.password.validation.PasswordValidationErrorCodes;
 import nl._42.password.validation.PasswordValidationFailedException;
 import nl._42.password.validation.ValidationRule;
-import nl._42.password.validation.OldPasswordRepository;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
@@ -23,8 +23,8 @@ public class PasswordNotUsedInPastRule implements ValidationRule {
     }
 
     @Override
-    public void validate(String password, Authentication authentication) {
-        if (oldPasswordRepository.getOldPasswords(authentication)
+    public void validate(String password, PasswordHolder passwordHolder) {
+        if (oldPasswordRepository.getOldPasswords(passwordHolder)
                 .stream()
                 .anyMatch(oldPassword -> passwordEncoder.matches(password, oldPassword))) {
             throw new PasswordValidationFailedException(PasswordValidationErrorCodes.USED_IN_PAST);

--- a/src/main/java/nl/_42/password/validation/rule/PasswordStrengthRule.java
+++ b/src/main/java/nl/_42/password/validation/rule/PasswordStrengthRule.java
@@ -1,12 +1,12 @@
 package nl._42.password.validation.rule;
 
+import nl._42.password.validation.PasswordHolder;
 import nl._42.password.validation.PasswordProperties;
 import nl._42.password.validation.PasswordValidationErrorCodes;
 import nl._42.password.validation.PasswordValidationFailedException;
 import nl._42.password.validation.ValidationRule;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -20,7 +20,7 @@ public class PasswordStrengthRule implements ValidationRule {
     }
 
     @Override
-    public void validate(String password, Authentication authentication) {
+    public void validate(String password, PasswordHolder passwordHolder) {
         if (!password.matches(passwordProperties.getStrengthRegex())) {
             throw new PasswordValidationFailedException(PasswordValidationErrorCodes.NOT_STRONG_ENOUGH);
         }

--- a/src/test/java/nl/_42/password/PasswordHolderImpl.java
+++ b/src/test/java/nl/_42/password/PasswordHolderImpl.java
@@ -1,0 +1,15 @@
+package nl._42.password;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import nl._42.password.validation.PasswordHolder;
+
+@AllArgsConstructor
+@Getter
+@NoArgsConstructor
+@Setter
+public class PasswordHolderImpl implements PasswordHolder {
+    private String password;
+}

--- a/src/test/java/nl/_42/password/rule/PasswordDifferentThanCurrentRuleTest.java
+++ b/src/test/java/nl/_42/password/rule/PasswordDifferentThanCurrentRuleTest.java
@@ -2,15 +2,13 @@ package nl._42.password.rule;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import nl._42.password.validation.CredentialRetriever;
+import nl._42.password.PasswordHolderImpl;
+import nl._42.password.validation.PasswordHolder;
 import nl._42.password.validation.PasswordValidationFailedException;
-import nl._42.password.validation.PasswordValidatorAutoConfiguration;
 import nl._42.password.validation.rule.PasswordDifferentThanCurrentRule;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
@@ -18,24 +16,22 @@ class PasswordDifferentThanCurrentRuleTest {
 
     private static final String password = "Password01!";
     private PasswordEncoder passwordEncoder;
-    private Authentication authenticationToken;
-    private CredentialRetriever credentialRetriever;
+    private PasswordHolder passwordHolder;
 
     @BeforeEach
     void setUp() {
         passwordEncoder = new BCryptPasswordEncoder();
-        authenticationToken = new UsernamePasswordAuthenticationToken(1, passwordEncoder.encode(password), null);
-        credentialRetriever = new PasswordValidatorAutoConfiguration().credentialRetriever();
+        passwordHolder = new PasswordHolderImpl(passwordEncoder.encode(password));
     }
 
     @Test
     void validate_shouldSucceed() {
-        new PasswordDifferentThanCurrentRule(passwordEncoder, credentialRetriever).validate("NewPassword02@", authenticationToken);
+        new PasswordDifferentThanCurrentRule(passwordEncoder).validate("NewPassword02@", passwordHolder);
     }
 
     @Test
     void validate_shouldThrow_onMatchingPasswords() {
-        PasswordDifferentThanCurrentRule rule = new PasswordDifferentThanCurrentRule(passwordEncoder, credentialRetriever);
-        assertThrows(PasswordValidationFailedException.class, () -> rule.validate(password, authenticationToken));
+        PasswordDifferentThanCurrentRule rule = new PasswordDifferentThanCurrentRule(passwordEncoder);
+        assertThrows(PasswordValidationFailedException.class, () -> rule.validate(password, passwordHolder));
     }
 }


### PR DESCRIPTION
Authentication tokens were flawed. Didn't always have a password, weren't always based on username/password, etc.
Now using a new interface PasswordHolder. Users of the library have to implement this interface in their User/Person/equivalent class to return the current (encoded) password.